### PR TITLE
Fixed occasional crash due to _queuedbuffer being empty during loop

### DIFF
--- a/Audio/StreamedSoundEffectInstance.OpenAL.cs
+++ b/Audio/StreamedSoundEffectInstance.OpenAL.cs
@@ -53,8 +53,10 @@ namespace MonoSound.Audio {
 			// Remove all queued buffers
 			AL.Source(SourceId, ALSourcei.Buffer, 0);
 			while (_queuedBuffers.Count > 0) {
-				var buffer = _queuedBuffers.Dequeue();
-				buffer.Dispose();
+                if (_queuedBuffers.TryDequeue(out var buffer))
+                {
+                    buffer.Dispose();
+                }
 			}
 		}
 

--- a/Audio/StreamedSoundEffectInstance.OpenAL.cs
+++ b/Audio/StreamedSoundEffectInstance.OpenAL.cs
@@ -52,13 +52,17 @@ namespace MonoSound.Audio {
 
 			// Remove all queued buffers
 			AL.Source(SourceId, ALSourcei.Buffer, 0);
-			while (_queuedBuffers.Count > 0) {
-                if (_queuedBuffers.TryDequeue(out var buffer))
+            lock (_queuedBuffers)
+            {
+                while (_queuedBuffers.Count > 0)
                 {
-                    buffer.Dispose();
+                    if (_queuedBuffers.TryDequeue(out var buffer))
+                    {
+                        buffer.Dispose();
+                    }
                 }
-			}
-		}
+            }
+        }
 
 		private void PlatformSubmitBuffer(byte[] buffer, int offset, int count) {
 			// Get a buffer


### PR DESCRIPTION
StreamedSoundEffectInstance.PlatformStop()  can attempt to dequeue from_queuedBuffers once all object have been disposed. I'm not quite good enough at debugging to find if it's a concurrency Issue and _queuedBuffers is being modified from another thread while this loop is running, or if it's a race Condition with OpenAL Calls, but for me, locking it and using TryDequeue prevents it.