### PR TITLE
add direct dependency to NVorbis, bump MonoGame version

### DIFF
--- a/Audio/FormatWav.cs
+++ b/Audio/FormatWav.cs
@@ -272,7 +272,7 @@ namespace MonoSound.Audio {
 			 *  ----
 			 */
 
-			using VorbisReader reader = new VorbisReader(readStream, closeStreamOnDispose: true);
+			using VorbisReader reader = new VorbisReader(readStream, closeOnDispose: true);
 
 			byte[] fmtChunk = [
 				0x01, 0x00,

--- a/MonoSound.Tests/Game1.cs
+++ b/MonoSound.Tests/Game1.cs
@@ -161,7 +161,7 @@ namespace MonoSound.Tests {
 
 		static readonly List<Keys> currentSequence = [];
 
-		protected override void OnExiting(object sender, EventArgs args) {
+		protected override void OnExiting(object sender, ExitingEventArgs args) {
 			MonoSoundLibrary.DeInit();
 		}
 

--- a/MonoSound.Tests/MonoSound.Tests.csproj
+++ b/MonoSound.Tests/MonoSound.Tests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FontStashSharp.MonoGame" Version="1.2.7" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="MP3Sharp" Version="1.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/MonoSound.csproj
+++ b/MonoSound.csproj
@@ -27,9 +27,10 @@ Check CHANGELOG.md for the full list of changes.</PackageReleaseNotes>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="MP3SharpWithMonoFix" Version="1.0.6" />
 	<PackageReference Include="Krafs.Publicizer" Version="2.2.1" PrivateAssets="all" />
+    <PackageReference Include="NVorbis" Version="0.10.5" />
 	
 	<Publicize Include="MonoGame.Framework" />
 

--- a/MonoSound.csproj
+++ b/MonoSound.csproj
@@ -30,7 +30,6 @@ Check CHANGELOG.md for the full list of changes.</PackageReleaseNotes>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="MP3SharpWithMonoFix" Version="1.0.6" />
 	<PackageReference Include="Krafs.Publicizer" Version="2.2.1" PrivateAssets="all" />
-    <PackageReference Include="NVorbis" Version="0.10.5" />
 	
 	<Publicize Include="MonoGame.Framework" />
 

--- a/Streaming/AudioStreams.cs
+++ b/Streaming/AudioStreams.cs
@@ -172,7 +172,7 @@ namespace MonoSound.Streaming {
 		/// <param name="file">The absolute or relative location of the file to read from</param>
 		public OggStream(string file) : base(AudioType.OGG) {
 			// NOTE: VorbisReader(string) uses File.OpenRead() and we need TitleContainer.OpenStream() instead
-			vorbisStream = new NVorbis.VorbisReader(TitleContainer.OpenStream(file), closeStreamOnDispose: true);
+			vorbisStream = new NVorbis.VorbisReader(TitleContainer.OpenStream(file), closeOnDispose: true);
 
 			Initialize();
 		}
@@ -182,7 +182,7 @@ namespace MonoSound.Streaming {
 		/// </summary>
 		/// <param name="stream">The data stream to read from</param>
 		public OggStream(Stream stream) : base(AudioType.OGG) {
-			vorbisStream = new NVorbis.VorbisReader(stream, closeStreamOnDispose: true);
+			vorbisStream = new NVorbis.VorbisReader(stream, closeOnDispose: true);
 
 			Initialize();
 		}


### PR DESCRIPTION
Addresses #8  .

By adding a direct dependency on NVorbis, this ensures that the package will always be available (no matter what happens with the dependency within MonoGame). That being said, it looks like NVorbis changed the `closeStreamOnDispose` parameter to `closeOnDispose` in the VorbisReader constructor, so that has been updated across the board.

I've also bumped the target MonoGame version to the latest stable build.

Confirmed that all of the tests are still functional, and I've also used this build of the library in my own personal project (which was having the issue outlined above) and it is working now.